### PR TITLE
Make `migrad!()` to use `robust_low_level_fit` by default

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -864,6 +864,16 @@ function mnprofile(m::Minuit, var; size=30, bound=2, grid=nothing, subtract_min=
     return x, y, status
 end
 
+"""
+    robust_low_level_fit(fcn, state, ncall, strategy, tolerance, precision, iterate, use_simplex)
+
+A meta algorithm that:
+
+1. runs Migrad with user-specified configs (such as strategy and tolerance)
+2. checks if we converged
+3. if not, sets strategy=2, and start running N more iterations
+3. in each additional iteration, if `use_simplex`, runs SIMPLEX (again, think NelderMead) first, followed by a Migrad
+"""
 function robust_low_level_fit(fcn, state, ncall, strategy, tolerance, precision, iterate, use_simplex)
     migrad = MnMigrad(fcn, state, strategy)
     isnothing(precision) || SetPrecision(migrad, precision)

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -128,6 +128,21 @@
 
     end
 
+    @testset "Migrad with low_level_robust_fit" begin
+        fn(x, p1, p2, p3) = p1 * x^(p2*log(x)^2 + p3*log(x)^3) + randn()
+
+        true_ys = fn.(1:10, 10, 0.1, 0.01)
+        m = Minuit(LeastSquares(1:10, true_ys, sqrt.(true_ys), fn), fill(0.1, 3); strategy=0, tolerance=1e-3)
+        migrad!(m; iterate=1)
+        naive_loss = m.fval
+
+        m = Minuit(LeastSquares(1:10, true_ys, sqrt.(true_ys), fn), fill(0.1, 3); strategy=0, tolerance=1e-3)
+        migrad!(m)
+        iterated_loss = m.fval
+
+        @test iterated_loss < naive_loss
+    end
+
     @testset "Minuit with gradient" begin
         m = Minuit(rosenbrock, [0.0, 0.0], grad=rosenbrock_grad, tolerance=1e-5)
 


### PR DESCRIPTION
fix #25 

Ref: https://scikit-hep.org/iminuit/reference.html#iminuit.Minuit.migrad 

tests inspired by https://github.com/scikit-hep/iminuit/blob/develop/doc/notebooks/unstable_fit.ipynb

they also make `iterate` and `use_simplex` an option at this API